### PR TITLE
Debug initial launch

### DIFF
--- a/analysis/analysis_etl.Rmd
+++ b/analysis/analysis_etl.Rmd
@@ -97,13 +97,22 @@ is.debug <- case_when(
 print(glue('Debugging ETL pipeline: {is.debug}'))
 
 # Minimum build ID to process. Apply this as a query filter to retrieve only new, unprocessed, builds. 
-min_build_id <- case_when(
-  Sys.getenv("MIN_BUILD_ID") == '' ~ bq_project_query(project_id, build_min_build_id_query(tbl.main, num_build_dates)) %>%
+if (Sys.getenv("MIN_BUILD_ID") == ''){
+  min_build_id <- bq_project_query(project_id, build_min_build_id_query(tbl.main, num_build_dates)) %>%
     bq_table_download() %>%
     pull(max_build_date) %>% 
-    format('%Y%m%d'),
-  TRUE ~ Sys.getenv("MIN_BUILD_ID") 
-)
+    format('%Y%m%d')
+  if (as.integer(min_build_id) < exp_min_build_id) min_build_id <- exp_min_build_id
+} else Sys.getenv("MIN_BUILD_ID") 
+
+# min_build_id <- case_when(
+#   Sys.getenv("MIN_BUILD_ID") == '' ~ bq_project_query(project_id, build_min_build_id_query(tbl.main, num_build_dates)) %>%
+#     bq_table_download() %>%
+#     pull(max_build_date) %>% 
+#     format('%Y%m%d'),
+#   TRUE ~ Sys.getenv("MIN_BUILD_ID") 
+# )
+
 print(glue('Processing builds >= {min_build_id}'))
 
 print(glue('Utilizing {bs_replicates} bootstrap relicates'))
@@ -132,7 +141,19 @@ process_histograms <- function(probe) {
       build_hist_query(probes.hist[[probe]], slug, tbl.main, min_build_id)
      hist <- bq_project_query(project_id, hist_query)
      hist.df <- bq_table_download(hist) %>%
+       mutate(branch = case_when(
+        branch == 'fission-enabled' ~ 'enabled',
+         TRUE ~ 'disabled'
+       )) %>%
        as.data.table()
+     
+     #FIXME: filter out keys not corresponding to enough data
+     key_count <- hist.df %>% count(build_id, key)
+     if (nrow(key_count) > 0) {
+       print(glue('WARNING: filter {nkeys} number of keys from histogram due to lacking branch', nkeys=nrow(key_count)))
+        hist.df <- hist.df %>% left_join(key_count) %>%
+          filter(n > 1)
+     }
     
      hist.summary <- summarize.hist(hist.df) %>%
        mutate(probe = probe) %>%
@@ -162,6 +183,10 @@ Pull the each's build per daily average of the scalars.
 ```{r scalar_import}
 scalar <- bq_project_query(project_id, build_scalar_query(probes.scalar.sum, probes.scalar.max, slug, tbl.main, min_build_id))
 scalar.df <- bq_table_download(scalar) %>%
+     mutate(branch = case_when(
+        branch == 'fission-enabled' ~ 'enabled',
+         TRUE ~ 'disabled'
+       )) %>%
   as.data.table()
 
 scalar.df.nrow <- nrow(scalar.df)

--- a/analysis/analysis_etl.Rmd
+++ b/analysis/analysis_etl.Rmd
@@ -105,14 +105,6 @@ if (Sys.getenv("MIN_BUILD_ID") == ''){
   if (as.integer(min_build_id) < exp_min_build_id) min_build_id <- exp_min_build_id
 } else Sys.getenv("MIN_BUILD_ID") 
 
-# min_build_id <- case_when(
-#   Sys.getenv("MIN_BUILD_ID") == '' ~ bq_project_query(project_id, build_min_build_id_query(tbl.main, num_build_dates)) %>%
-#     bq_table_download() %>%
-#     pull(max_build_date) %>% 
-#     format('%Y%m%d'),
-#   TRUE ~ Sys.getenv("MIN_BUILD_ID") 
-# )
-
 print(glue('Processing builds >= {min_build_id}'))
 
 print(glue('Utilizing {bs_replicates} bootstrap relicates'))
@@ -152,7 +144,8 @@ process_histograms <- function(probe) {
      if (nrow(key_count) > 0) {
        print(glue('WARNING: filter {nkeys} number of keys from histogram due to lacking branch', nkeys=nrow(key_count)))
         hist.df <- hist.df %>% left_join(key_count) %>%
-          filter(n > 1)
+          filter(n > 1) %>%
+          as.data.table()
      }
     
      hist.summary <- summarize.hist(hist.df) %>%

--- a/analysis/dashboard.Rmd
+++ b/analysis/dashboard.Rmd
@@ -128,7 +128,7 @@ max_build_id <- bq_project_query(project_id,
   pull(max_build_id)
 ```
 
-Information for builds till `r as.Date(as.character(max_build_id), format = '%Y%m%d')`.
+Information for builds up to `r as.Date(as.character(max_build_id), format = '%Y%m%d')`.
 
 ##  {.tabset}
 

--- a/analysis/params.R
+++ b/analysis/params.R
@@ -1,6 +1,7 @@
 #### Experiment-specific ####
 
 slug <- 'bug-1660366-pref-ongoing-fission-nightly-experiment-nightly-83-100'
+exp_min_build_id <- 20201012
 
 #### Analysis-specific ####
 # Breakdown by how probes are analyzed # 


### PR DESCRIPTION
Filtering out recording to process and display to those builds corresponding to experiment (e.g. builds >= '2020-10-12'). 

In addition, dealing with bug regarding differing branch enum values in `main` table (fission-[enabled|disabled]), versus those in `crash` (enabled|disabled). The latter is the chosen convention.  