### PR TITLE
Os segments

### DIFF
--- a/analysis/analysis_etl.Rmd
+++ b/analysis/analysis_etl.Rmd
@@ -66,6 +66,7 @@ margin-top: 100px;
 source('params.R')
 source('query.R')
 source('stats.R')
+source('process.R')
 ```
 
 
@@ -119,86 +120,41 @@ options(scipen = 20) # bigrquery bug: https://github.com/r-dbi/bigrquery/issues/
 Perform the histogram aggregation server-side. This is most easy achieved processing a histogram at a time. 
 
 ```{r hist_agg_var}
-results.hist <- list()
-hists.raw <- list()  
+results.hist <- results.hist.win <- results.hist.osx <- results.hist.linux <- list()
+# hists.raw <- list()  
 ```
 
 ```{r hist_agg}
 print('Processing histograms')
-process_histograms <- function(probe) {
-  hist.res <- tryCatch({
-    print(probe)
-    hist_query <-
-      build_hist_query(probes.hist[[probe]], slug, tbl.main, min_build_id)
-     hist <- bq_project_query(project_id, hist_query)
-     hist.df <- bq_table_download(hist) %>%
-       mutate(branch = case_when(
-        branch == 'fission-enabled' ~ 'enabled',
-         TRUE ~ 'disabled'
-       )) %>%
-       as.data.table()
-     
-     hist.summary <- summarize.hist(hist.df) %>%
-       mutate(probe = probe) %>%
-       rename(branch = what)
-     list(raw = hist.df, summary = hist.summary)
-   },
-  error = function(err) {
-     print(glue("ERROR processsing {probe}: {err}"))
-     return(c(raw = NULL, summary = NULL))
-   })
-  return(hist.res) 
-}
 
 for (probe in names(probes.hist)) {
-  hist.res <- process_histograms(probe)
-  results.hist[[probe]] <- hist.res$summary
-  hists.raw[[probe]] <- hist.res$raw
+  results.hist[[probe]] <- process_histograms(probe)$summary
+  results.hist.win[[probe]] <- process_histograms(probe, os='Windows')$summary
+  results.hist.osx[[probe]] <- process_histograms(probe, os='Mac')$summary
+  results.hist.linux[[probe]] <- process_histograms(probe, os='Linux')$summary
   if (is.debug)
-    break
+     break
 }
 ```
+
 
 ```{r hist_agg_95th}
 print('Processing histograms: 95th percentile')
 
-process_histograms_95th <- function(probe) {
-  hist.res <- tryCatch({
-    print(probe)
-    hist_query <-
-      build_hist_query(probes.hist.perc.95[[probe]], slug, tbl.main, min_build_id)
-     hist <- bq_project_query(project_id, hist_query)
-     hist.df <- bq_table_download(hist) %>%
-       mutate(branch = case_when(
-        branch == 'fission-enabled' ~ 'enabled',
-         TRUE ~ 'disabled'
-       )) %>%
-       as.data.table()
-    
-     hist.summary.95th <- summarize.hist.perc(hist.df, 0.95) %>%
-       mutate(probe = probe) %>%
-       rename(branch = what)
-     list(raw = hist.df, summary = hist.summary.95th)
-   },
-  error = function(err) {
-     print(glue("ERROR processsing {probe}: {err}"))
-     return(c(raw = NULL, summary = NULL))
-   })
-  return(hist.res) 
-}
-
 for (probe in names(probes.hist.perc.95)) {
-  hist.res <- process_histograms_95th(probe)
-  results.hist[[probe]] <- hist.res$summary
-  hists.raw[[probe]] <- hist.res$raw
+  results.hist[[probe]] <- process_histograms_95th(probe)$summary
+  results.hist[[probe]] <- process_histograms_95th(probe, os='Windows')$summary
+  results.hist[[probe]] <- process_histograms_95th(probe, os='Mac')$summary
+  results.hist[[probe]] <- process_histograms_95th(probe, os='Linux')$summary
   if (is.debug)
     break
 }
 ```
 
 
-# Scalar Aggregation
+# Scalar Aggregation{.tabset}
 
+## OS: ALL
 Pull the each's build per daily average of the scalars. 
 ```{r scalar_import}
 scalar <- bq_project_query(project_id, build_scalar_query(probes.scalar.sum, probes.scalar.max, slug, tbl.main, min_build_id))
@@ -221,28 +177,113 @@ results.scalar <- list()
 if (is.debug)
   bs_replicates <- 20
 
-process_scalar <- function(probe) {
-  scalar.res <- tryCatch({
-      scalar.df[get(probe) < quantile(get(probe), perc.high, na.rm = TRUE),
-                summarize.scalar(.SD[, list(id, branch, x =
-                                              get(probe))], "x", bs_replicates, stat = mean.narm),
-                by = build_id][, probe := probe][order(build_id, what),] %>%
-      rename(branch = what)
-  },
-  error = function(err) {
-    print(glue("ERROR processsing {probe}: {err}"))
-    return(NULL)
-  })
-  return(scalar.res)
-}
-
 for (probe in c(names(probes.scalar.sum), names(probes.scalar.max))) {
   print(probe)
-  results.scalar[[probe]] <- process_scalar(probe)
+  results.scalar[[probe]] <- process_scalar(scalar.df, probe, perc.high, bs_replicates)
   if (is.debug)
     break
 }
 ```
+
+
+## OS: Windows
+Pull the each's build per daily average of the scalars. 
+```{r scalar_import_win}
+scalar <- bq_project_query(project_id, build_scalar_query(probes.scalar.sum, probes.scalar.max, slug, tbl.main, min_build_id, os='Windows'))
+scalar.df <- bq_table_download(scalar) %>%
+     mutate(branch = case_when(
+        branch == 'fission-enabled' ~ 'enabled',
+         TRUE ~ 'disabled'
+       )) %>%
+  as.data.table()
+
+scalar.df.nrow <- nrow(scalar.df)
+if (is.debug) print(glue('Processing scalar data.frame {scalar.df.nrow}'))
+```
+
+
+Calculate means and confidence intervals. 
+```{r scalar_agg_win, warning=FALSE}
+results.scalar.win <- list()
+
+if (is.debug)
+  bs_replicates <- 20
+
+for (probe in c(names(probes.scalar.sum), names(probes.scalar.max))) {
+  print(probe)
+  results.scalar.win[[probe]] <- process_scalar(scalar.df, probe, perc.high, bs_replicates)
+  if (is.debug)
+    break
+}
+```
+
+
+
+## OS: Mac
+Pull the each's build per daily average of the scalars. 
+```{r scalar_import_osx}
+scalar <- bq_project_query(project_id, build_scalar_query(probes.scalar.sum, probes.scalar.max, slug, tbl.main, min_build_id, os='Mac'))
+scalar.df <- bq_table_download(scalar) %>%
+     mutate(branch = case_when(
+        branch == 'fission-enabled' ~ 'enabled',
+         TRUE ~ 'disabled'
+       )) %>%
+  as.data.table()
+
+scalar.df.nrow <- nrow(scalar.df)
+if (is.debug) print(glue('Processing scalar data.frame {scalar.df.nrow}'))
+```
+
+
+Calculate means and confidence intervals. 
+```{r scalar_agg_osx, warning=FALSE}
+results.scalar.osx <- list()
+
+if (is.debug)
+  bs_replicates <- 20
+
+for (probe in c(names(probes.scalar.sum), names(probes.scalar.max))) {
+  print(probe)
+  results.scalar.osx[[probe]] <- process_scalar(scalar.df, probe, perc.high, bs_replicates)
+  if (is.debug)
+    break
+}
+```
+
+
+
+## OS: Linux
+Pull the each's build per daily average of the scalars. 
+```{r scalar_import_linux}
+scalar <- bq_project_query(project_id, build_scalar_query(probes.scalar.sum, probes.scalar.max, slug, tbl.main, min_build_id, os='Linux'))
+scalar.df <- bq_table_download(scalar) %>%
+     mutate(branch = case_when(
+        branch == 'fission-enabled' ~ 'enabled',
+         TRUE ~ 'disabled'
+       )) %>%
+  as.data.table()
+
+scalar.df.nrow <- nrow(scalar.df)
+if (is.debug) print(glue('Processing scalar data.frame {scalar.df.nrow}'))
+```
+
+
+Calculate means and confidence intervals. 
+```{r scalar_agg_linux, warning=FALSE}
+results.scalar.linux <- list()
+
+if (is.debug)
+  bs_replicates <- 20
+
+for (probe in c(names(probes.scalar.sum), names(probes.scalar.max))) {
+  print(probe)
+  results.scalar.linux[[probe]] <- process_scalar(scalar.df, probe, perc.high, bs_replicates)
+  if (is.debug)
+    break
+}
+```
+
+
 
 # Crash Aggregation
 Perform a similar analysis for crashes.
@@ -260,27 +301,9 @@ Process the per usage hour probes.
 ```{r crashes_agg, warning=FALSE}
 results.crashes <- list()
 
-process_crash <- function(probe, stat=mean.narm, name = probe) {
-  crashes.res <- tryCatch({
-    print(probe)
-    crashes.df[get(probe) < quantile(get(probe), perc.high, na.rm = TRUE),
-               summarize.scalar(.SD[, list(id, branch, x =
-                                               get(probe))], "x",
-                                  bs_replicates, stat = stat),
-               by = build_id][, probe := probe][order(build_id, what), ] %>%
-      rename(branch = what) %>%
-      mutate(probe = name)
-  },
-  error = function(err) {
-    print(glue("ERROR processsing {probe}: {err}"))
-    return(NULL)
-  })
-  return(crashes.res)
-}
-
 for (probe in names(probes.crashes)) {
   probe_per_hour <- paste(probe, '_PER_HOUR', sep = '')
-  results.crashes[[probe_per_hour]] <- process_crash(probe_per_hour)
+  results.crashes[[probe_per_hour]] <- process_crash(probe_per_hour, perc.high, bs_replicates)
   if (is.debug)
     break
 }
@@ -292,6 +315,8 @@ client_count.stat <- function(x) length(which(!is.na(x) & x>0))
 for (probe in names(probes.crashes)) {
   probe_client_count <- paste(probe, '_CLIENT_COUNT', sep = '')
   results.crashes[[probe_client_count]] <- process_crash(probe, 
+                                                         perc.high,
+                                                         bs_replicates,
                                                      stat = client_count.stat,
                                                      name = probe_client_count)
   if (is.debug)
@@ -305,8 +330,18 @@ Combine the individual probes into a single `data.frame`.
 
 ```{r combine}
 final.df <- rbindlist(results.hist) %>%
-  rbind(., rbindlist(results.scalar)) %>%
-  rbind(., rbindlist(results.crashes)) %>%
+  mutate(os = 'All') %>%
+  rbind(., rbindlist(results.hist.win) %>% mutate(os = 'Windows')) %>%
+  rbind(., rbindlist(results.hist.osx) %>% mutate(os = 'Mac')) %>%
+  rbind(., rbindlist(results.hist.linux) %>% mutate(os = 'Linux')) %>%
+  rbind(., rbindlist(results.scalar) %>% mutate(os = 'All')) %>%
+  rbind(., rbindlist(results.scalar.win) %>% mutate(os = 'Windows')) %>%
+  rbind(., rbindlist(results.scalar.osx) %>% mutate(os = 'Mac')) %>%
+  rbind(., rbindlist(results.scalar.linux) %>% mutate(os = 'Linux')) %>%
+  rbind(., rbindlist(results.crashes) %>% mutate(os = 'All')) %>%
+  # rbind(., rbindlist(results.crashes.win) %>% mutate(os = 'Windows')) %>%
+  # rbind(., rbindlist(results.crashes.osx) %>% mutate(os = 'Mac')) %>%
+  # rbind(., rbindlist(results.crashes.linux) %>% mutate(os = 'Linux')) %>%
   mutate(date_computed = Sys.Date())
 
 final.nrow <- nrow(final.df)

--- a/analysis/analysis_etl.Rmd
+++ b/analysis/analysis_etl.Rmd
@@ -132,7 +132,7 @@ for (probe in names(probes.hist)) {
   results.hist.win[[probe]] <- process_histograms(probe, os='Windows')$summary
   results.hist.osx[[probe]] <- process_histograms(probe, os='Mac')$summary
   results.hist.linux[[probe]] <- process_histograms(probe, os='Linux')$summary
-  if (is.debug)
+  if (is.debug && probe != 'CHECKERBOARDING_SEVERITY')
      break
 }
 ```
@@ -142,20 +142,23 @@ for (probe in names(probes.hist)) {
 print('Processing histograms: 95th percentile')
 
 for (probe in names(probes.hist.perc.95)) {
-  results.hist[[probe]] <- process_histograms_95th(probe)$summary
-  results.hist[[probe]] <- process_histograms_95th(probe, os='Windows')$summary
-  results.hist[[probe]] <- process_histograms_95th(probe, os='Mac')$summary
-  results.hist[[probe]] <- process_histograms_95th(probe, os='Linux')$summary
-  if (is.debug)
+  if (is.debug) # TODO: This analysis takes WAY too long. Optimized bootstrapping. 
     break
+  results.hist[[probe]] <- process_histograms_95th(probe)$summary
+  # results.hist[[probe]] <- process_histograms_95th(probe, os='Windows')$summary
+  # results.hist[[probe]] <- process_histograms_95th(probe, os='Mac')$summary
+  # results.hist[[probe]] <- process_histograms_95th(probe, os='Linux')$summary
 }
 ```
 
 
 # Scalar Aggregation{.tabset}
 
+1. Pull the each's build per daily average of the scalars. 
+2. Calculate means and confidence intervals. 
+
 ## OS: ALL
-Pull the each's build per daily average of the scalars. 
+
 ```{r scalar_import}
 scalar <- bq_project_query(project_id, build_scalar_query(probes.scalar.sum, probes.scalar.max, slug, tbl.main, min_build_id))
 scalar.df <- bq_table_download(scalar) %>%
@@ -169,8 +172,6 @@ scalar.df.nrow <- nrow(scalar.df)
 if (is.debug) print(glue('Processing scalar data.frame {scalar.df.nrow}'))
 ```
 
-
-Calculate means and confidence intervals. 
 ```{r scalar_agg, warning=FALSE}
 results.scalar <- list()
 
@@ -187,7 +188,7 @@ for (probe in c(names(probes.scalar.sum), names(probes.scalar.max))) {
 
 
 ## OS: Windows
-Pull the each's build per daily average of the scalars. 
+
 ```{r scalar_import_win}
 scalar <- bq_project_query(project_id, build_scalar_query(probes.scalar.sum, probes.scalar.max, slug, tbl.main, min_build_id, os='Windows'))
 scalar.df <- bq_table_download(scalar) %>%
@@ -202,12 +203,9 @@ if (is.debug) print(glue('Processing scalar data.frame {scalar.df.nrow}'))
 ```
 
 
-Calculate means and confidence intervals. 
+
 ```{r scalar_agg_win, warning=FALSE}
 results.scalar.win <- list()
-
-if (is.debug)
-  bs_replicates <- 20
 
 for (probe in c(names(probes.scalar.sum), names(probes.scalar.max))) {
   print(probe)
@@ -220,7 +218,7 @@ for (probe in c(names(probes.scalar.sum), names(probes.scalar.max))) {
 
 
 ## OS: Mac
-Pull the each's build per daily average of the scalars. 
+
 ```{r scalar_import_osx}
 scalar <- bq_project_query(project_id, build_scalar_query(probes.scalar.sum, probes.scalar.max, slug, tbl.main, min_build_id, os='Mac'))
 scalar.df <- bq_table_download(scalar) %>%
@@ -235,7 +233,7 @@ if (is.debug) print(glue('Processing scalar data.frame {scalar.df.nrow}'))
 ```
 
 
-Calculate means and confidence intervals. 
+
 ```{r scalar_agg_osx, warning=FALSE}
 results.scalar.osx <- list()
 
@@ -253,7 +251,7 @@ for (probe in c(names(probes.scalar.sum), names(probes.scalar.max))) {
 
 
 ## OS: Linux
-Pull the each's build per daily average of the scalars. 
+
 ```{r scalar_import_linux}
 scalar <- bq_project_query(project_id, build_scalar_query(probes.scalar.sum, probes.scalar.max, slug, tbl.main, min_build_id, os='Linux'))
 scalar.df <- bq_table_download(scalar) %>%
@@ -268,7 +266,7 @@ if (is.debug) print(glue('Processing scalar data.frame {scalar.df.nrow}'))
 ```
 
 
-Calculate means and confidence intervals. 
+
 ```{r scalar_agg_linux, warning=FALSE}
 results.scalar.linux <- list()
 
@@ -285,9 +283,13 @@ for (probe in c(names(probes.scalar.sum), names(probes.scalar.max))) {
 
 
 
-# Crash Aggregation
-Perform a similar analysis for crashes.
+# Crash Aggregation{.tabset}
 
+1. Pull the each's build per daily average of the crashes.
+2. Process the per usage hour probes. 
+3. Process the distinct client crashing. 
+
+## OS: All
 ```{r crash_import}
 crashes <-  bq_project_query(project_id, build_crash_query(probes.crashes, slug, tbl.crashes, min_build_id))
 crashes.df <- bq_table_download(crashes) %>%
@@ -303,26 +305,142 @@ results.crashes <- list()
 
 for (probe in names(probes.crashes)) {
   probe_per_hour <- paste(probe, '_PER_HOUR', sep = '')
-  results.crashes[[probe_per_hour]] <- process_crash(probe_per_hour, perc.high, bs_replicates)
+  results.crashes[[probe_per_hour]] <- process_crash(crashes.df, probe_per_hour, perc.high, bs_replicates)
   if (is.debug)
     break
 }
 ```
 
-Process the distinct client crashing. 
 ```{r crashes_count_agg, warning=FALSE}
 client_count.stat <- function(x) length(which(!is.na(x) & x>0))
 for (probe in names(probes.crashes)) {
   probe_client_count <- paste(probe, '_CLIENT_COUNT', sep = '')
-  results.crashes[[probe_client_count]] <- process_crash(probe, 
+  results.crashes[[probe_client_count]] <- process_crash(crashes.df,
+                                                         probe, 
                                                          perc.high,
                                                          bs_replicates,
-                                                     stat = client_count.stat,
-                                                     name = probe_client_count)
+                                                         stat = client_count.stat,
+                                                         name = probe_client_count)
   if (is.debug)
     break
 }
 ```
+
+
+## OS: Windows
+```{r crash_import_win}
+crashes <-  bq_project_query(project_id, build_crash_query(probes.crashes, slug, tbl.crashes, min_build_id, os='Windows_NT'))
+crashes.df <- bq_table_download(crashes) %>%
+  as.data.table()
+
+crashes.df.nrow <- nrow(crashes.df)
+if (is.debug) print(glue('Processing crash data.frame {crashes.df.nrow}'))
+```
+
+Process the per usage hour probes. 
+```{r crashes_agg_win, warning=FALSE}
+results.crashes.win <- list()
+
+for (probe in names(probes.crashes)) {
+  probe_per_hour <- paste(probe, '_PER_HOUR', sep = '')
+  results.crashes.win[[probe_per_hour]] <- process_crash(probe_per_hour, perc.high, bs_replicates)
+  if (is.debug)
+    break
+}
+```
+
+```{r crashes_count_agg_win, warning=FALSE}
+client_count.stat <- function(x) length(which(!is.na(x) & x>0))
+for (probe in names(probes.crashes)) {
+  probe_client_count <- paste(probe, '_CLIENT_COUNT', sep = '')
+  results.crashes.win[[probe_client_count]] <- process_crash(probe, 
+                                                         perc.high,
+                                                         bs_replicates,
+                                                         stat = client_count.stat,
+                                                         name = probe_client_count)
+  if (is.debug)
+    break
+}
+```
+
+
+
+## OS: Mac
+```{r crash_import_mac}
+crashes <-  bq_project_query(project_id, build_crash_query(probes.crashes, slug, tbl.crashes, min_build_id, os='Darwin'))
+crashes.df <- bq_table_download(crashes) %>%
+  as.data.table()
+
+crashes.df.nrow <- nrow(crashes.df)
+if (is.debug) print(glue('Processing crash data.frame {crashes.df.nrow}'))
+```
+
+Process the per usage hour probes. 
+```{r crashes_agg_mac, warning=FALSE}
+results.crashes.mac <- list()
+
+for (probe in names(probes.crashes)) {
+  probe_per_hour <- paste(probe, '_PER_HOUR', sep = '')
+  results.crashes.mac[[probe_per_hour]] <- process_crash(crashes.df, probe_per_hour, perc.high, bs_replicates)
+  if (is.debug)
+    break
+}
+```
+
+```{r crashes_count_agg_mac, warning=FALSE}
+client_count.stat <- function(x) length(which(!is.na(x) & x>0))
+for (probe in names(probes.crashes)) {
+  probe_client_count <- paste(probe, '_CLIENT_COUNT', sep = '')
+  results.crashes.mac[[probe_client_count]] <- process_crash(crashes.df,
+                                                             probe, 
+                                                             perc.high,
+                                                             bs_replicates,
+                                                             stat = client_count.stat,
+                                                             name = probe_client_count)
+  if (is.debug)
+    break
+}
+```
+
+
+## OS: Linux
+```{r crash_import_linux}
+crashes <-  bq_project_query(project_id, build_crash_query(probes.crashes, slug, tbl.crashes, min_build_id, os='Linux'))
+crashes.df <- bq_table_download(crashes) %>%
+  as.data.table()
+
+crashes.df.nrow <- nrow(crashes.df)
+if (is.debug) print(glue('Processing crash data.frame {crashes.df.nrow}'))
+```
+
+Process the per usage hour probes. 
+```{r crashes_agg_linux, warning=FALSE}
+results.crashes.linux <- list()
+
+for (probe in names(probes.crashes)) {
+  probe_per_hour <- paste(probe, '_PER_HOUR', sep = '')
+  results.crashes.linux[[probe_per_hour]] <- process_crash(crashes.df, probe_per_hour, perc.high, bs_replicates)
+  if (is.debug)
+    break
+}
+```
+
+```{r crashes_count_agg_linux, warning=FALSE}
+client_count.stat <- function(x) length(which(!is.na(x) & x>0))
+for (probe in names(probes.crashes)) {
+  probe_client_count <- paste(probe, '_CLIENT_COUNT', sep = '')
+  results.crashes.linux[[probe_client_count]] <- process_crash(crashes.df, 
+                                                             probe, 
+                                                         perc.high,
+                                                         bs_replicates,
+                                                         stat = client_count.stat,
+                                                         name = probe_client_count)
+  if (is.debug)
+    break
+}
+```
+
+
 
 # Export
 
@@ -339,9 +457,9 @@ final.df <- rbindlist(results.hist) %>%
   rbind(., rbindlist(results.scalar.osx) %>% mutate(os = 'Mac')) %>%
   rbind(., rbindlist(results.scalar.linux) %>% mutate(os = 'Linux')) %>%
   rbind(., rbindlist(results.crashes) %>% mutate(os = 'All')) %>%
-  # rbind(., rbindlist(results.crashes.win) %>% mutate(os = 'Windows')) %>%
-  # rbind(., rbindlist(results.crashes.osx) %>% mutate(os = 'Mac')) %>%
-  # rbind(., rbindlist(results.crashes.linux) %>% mutate(os = 'Linux')) %>%
+  rbind(., rbindlist(results.crashes.win) %>% mutate(os = 'Windows')) %>%
+  rbind(., rbindlist(results.crashes.osx) %>% mutate(os = 'Mac')) %>%
+  rbind(., rbindlist(results.crashes.linux) %>% mutate(os = 'Linux')) %>%
   mutate(date_computed = Sys.Date())
 
 final.nrow <- nrow(final.df)

--- a/analysis/analysis_etl.Rmd
+++ b/analysis/analysis_etl.Rmd
@@ -503,6 +503,7 @@ gc()
 
 # TODO
 
+* Deletion of records should be smart: e.g., only delete metric fields with successful analysis. 
 * For scalar query, perform dense_rank on client_id to get `id` field
 * Scalar bootstrapping should all be done with same replicates. Statistically more sound, and MUCH faster. 
 * Dynamically name control/treatment in stats.R

--- a/analysis/analysis_etl.Rmd
+++ b/analysis/analysis_etl.Rmd
@@ -343,7 +343,7 @@ results.crashes.win <- list()
 
 for (probe in names(probes.crashes)) {
   probe_per_hour <- paste(probe, '_PER_HOUR', sep = '')
-  results.crashes.win[[probe_per_hour]] <- process_crash(probe_per_hour, perc.high, bs_replicates)
+  results.crashes.win[[probe_per_hour]] <- process_crash(crasshes.df, probe_per_hour, perc.high, bs_replicates)
   if (is.debug)
     break
 }
@@ -353,11 +353,12 @@ for (probe in names(probes.crashes)) {
 client_count.stat <- function(x) length(which(!is.na(x) & x>0))
 for (probe in names(probes.crashes)) {
   probe_client_count <- paste(probe, '_CLIENT_COUNT', sep = '')
-  results.crashes.win[[probe_client_count]] <- process_crash(probe, 
-                                                         perc.high,
-                                                         bs_replicates,
-                                                         stat = client_count.stat,
-                                                         name = probe_client_count)
+  results.crashes.win[[probe_client_count]] <- process_crash(crashes.df,
+                                                             probe, 
+                                                             perc.high,
+                                                             bs_replicates,
+                                                             stat = client_count.stat,
+                                                             name = probe_client_count)
   if (is.debug)
     break
 }
@@ -377,11 +378,11 @@ if (is.debug) print(glue('Processing crash data.frame {crashes.df.nrow}'))
 
 Process the per usage hour probes. 
 ```{r crashes_agg_mac, warning=FALSE}
-results.crashes.mac <- list()
+results.crashes.osx <- list()
 
 for (probe in names(probes.crashes)) {
   probe_per_hour <- paste(probe, '_PER_HOUR', sep = '')
-  results.crashes.mac[[probe_per_hour]] <- process_crash(crashes.df, probe_per_hour, perc.high, bs_replicates)
+  results.crashes.osx[[probe_per_hour]] <- process_crash(crashes.df, probe_per_hour, perc.high, bs_replicates)
   if (is.debug)
     break
 }
@@ -391,7 +392,7 @@ for (probe in names(probes.crashes)) {
 client_count.stat <- function(x) length(which(!is.na(x) & x>0))
 for (probe in names(probes.crashes)) {
   probe_client_count <- paste(probe, '_CLIENT_COUNT', sep = '')
-  results.crashes.mac[[probe_client_count]] <- process_crash(crashes.df,
+  results.crashes.osx[[probe_client_count]] <- process_crash(crashes.df,
                                                              probe, 
                                                              perc.high,
                                                              bs_replicates,

--- a/analysis/analysis_etl.Rmd
+++ b/analysis/analysis_etl.Rmd
@@ -343,7 +343,7 @@ results.crashes.win <- list()
 
 for (probe in names(probes.crashes)) {
   probe_per_hour <- paste(probe, '_PER_HOUR', sep = '')
-  results.crashes.win[[probe_per_hour]] <- process_crash(crasshes.df, probe_per_hour, perc.high, bs_replicates)
+  results.crashes.win[[probe_per_hour]] <- process_crash(crashes.df, probe_per_hour, perc.high, bs_replicates)
   if (is.debug)
     break
 }

--- a/analysis/dashboard.Rmd
+++ b/analysis/dashboard.Rmd
@@ -326,6 +326,132 @@ vw(list(config = list(
 vconcat = crash_plots) , TRUE)
 ```
 
+##### Windows
+
+```{r crash_rates_win, eval=TRUE}
+# query analyzed per hour data
+crashes <- list()
+for (probe in names(probes.crashes)) {
+  probe_per_hour <- paste(probe, '_PER_HOUR', sep = '')
+  crashes[[probe_per_hour]] <-
+    bq_project_query(project_id,
+                     build_analyzed_probe_query(tbl.analyzed, probe = probe_per_hour, os='Windows')) %>%
+    bq_table_download() %>%
+    as.data.table()
+}
+
+crash_plots <- list()
+
+for (probe in names(crashes)) {
+  df <- crashes[[probe]]
+  if (nrow(df) > 0) {
+    # print(probe)
+    crash_plots[[length(crash_plots) + 1]] <-
+      create.figure(
+        df,
+        title = probe,
+        yaxislab = 'Estimate',
+        width = W / 1.85,
+        height = H,
+        LA = 90
+      )
+  }
+}
+
+vw(list(config = list(
+  legend = list(
+    direction = 'horizontal',
+    orient = 'top',
+    title = NULL
+  )
+),
+vconcat = crash_plots) , TRUE)
+```
+
+##### Mac
+
+```{r crash_rates_mac, eval=TRUE}
+# query analyzed per hour data
+crashes <- list()
+for (probe in names(probes.crashes)) {
+  probe_per_hour <- paste(probe, '_PER_HOUR', sep = '')
+  crashes[[probe_per_hour]] <-
+    bq_project_query(project_id,
+                     build_analyzed_probe_query(tbl.analyzed, probe = probe_per_hour, os='Mac')) %>%
+    bq_table_download() %>%
+    as.data.table()
+}
+
+crash_plots <- list()
+
+for (probe in names(crashes)) {
+  df <- crashes[[probe]]
+  if (nrow(df) > 0) {
+    # print(probe)
+    crash_plots[[length(crash_plots) + 1]] <-
+      create.figure(
+        df,
+        title = probe,
+        yaxislab = 'Estimate',
+        width = W / 1.85,
+        height = H,
+        LA = 90
+      )
+  }
+}
+
+vw(list(config = list(
+  legend = list(
+    direction = 'horizontal',
+    orient = 'top',
+    title = NULL
+  )
+),
+vconcat = crash_plots) , TRUE)
+```
+
+##### Linux
+
+```{r crash_rates_linux, eval=TRUE}
+# query analyzed per hour data
+crashes <- list()
+for (probe in names(probes.crashes)) {
+  probe_per_hour <- paste(probe, '_PER_HOUR', sep = '')
+  crashes[[probe_per_hour]] <-
+    bq_project_query(project_id,
+                     build_analyzed_probe_query(tbl.analyzed, probe = probe_per_hour, os='Linux')) %>%
+    bq_table_download() %>%
+    as.data.table()
+}
+
+crash_plots <- list()
+
+for (probe in names(crashes)) {
+  df <- crashes[[probe]]
+  if (nrow(df) > 0) {
+    # print(probe)
+    crash_plots[[length(crash_plots) + 1]] <-
+      create.figure(
+        df,
+        title = probe,
+        yaxislab = 'Estimate',
+        width = W / 1.85,
+        height = H,
+        LA = 90
+      )
+  }
+}
+
+vw(list(config = list(
+  legend = list(
+    direction = 'horizontal',
+    orient = 'top',
+    title = NULL
+  )
+),
+vconcat = crash_plots) , TRUE)
+```
+
 #### Crash Rates: Unique Client Count{.tabset}
 
 ##### OS: ALL
@@ -368,6 +494,135 @@ vw(list(config = list(
 ),
 vconcat = crash_client_count_plots) , TRUE)
 ```
+
+
+##### Windows
+```{r crash_rates_nclients_win, eval=TRUE}
+# query analyzed per hour data
+crashes_client_count <- list()
+for (probe in names(probes.crashes)) {
+  probe_client_count <- paste(probe, '_CLIENT_COUNT', sep = '')
+  crashes_client_count[[probe_client_count]] <-
+    bq_project_query(project_id,
+                     build_analyzed_probe_query(tbl.analyzed, probe = probe_client_count, os='Windows')) %>%
+    bq_table_download() %>%
+    as.data.table()
+}
+
+crash_client_count_plots <- list()
+
+for (probe in names(crashes_client_count)) {
+  df <- crashes_client_count[[probe]]
+  if (nrow(df) > 0) {
+    # print(probe)
+    crash_client_count_plots[[length(crash_client_count_plots) + 1]] <-
+      create.figure(
+        df,
+        title = probe,
+        yaxislab = 'Estimate',
+        width = W / 1.85,
+        height = H,
+        LA = 90
+      )
+  }
+}
+
+vw(list(config = list(
+  legend = list(
+    direction = 'horizontal',
+    orient = 'top',
+    title = NULL
+  )
+),
+vconcat = crash_client_count_plots) , TRUE)
+```
+
+
+
+##### Mac
+```{r crash_rates_nclients_mac, eval=TRUE}
+# query analyzed per hour data
+crashes_client_count <- list()
+for (probe in names(probes.crashes)) {
+  probe_client_count <- paste(probe, '_CLIENT_COUNT', sep = '')
+  crashes_client_count[[probe_client_count]] <-
+    bq_project_query(project_id,
+                     build_analyzed_probe_query(tbl.analyzed, probe = probe_client_count, os='Mac')) %>%
+    bq_table_download() %>%
+    as.data.table()
+}
+
+crash_client_count_plots <- list()
+
+for (probe in names(crashes_client_count)) {
+  df <- crashes_client_count[[probe]]
+  if (nrow(df) > 0) {
+    # print(probe)
+    crash_client_count_plots[[length(crash_client_count_plots) + 1]] <-
+      create.figure(
+        df,
+        title = probe,
+        yaxislab = 'Estimate',
+        width = W / 1.85,
+        height = H,
+        LA = 90
+      )
+  }
+}
+
+vw(list(config = list(
+  legend = list(
+    direction = 'horizontal',
+    orient = 'top',
+    title = NULL
+  )
+),
+vconcat = crash_client_count_plots) , TRUE)
+```
+
+
+
+##### Linux
+```{r crash_rates_nclients_linux, eval=TRUE}
+# query analyzed per hour data
+crashes_client_count <- list()
+for (probe in names(probes.crashes)) {
+  probe_client_count <- paste(probe, '_CLIENT_COUNT', sep = '')
+  crashes_client_count[[probe_client_count]] <-
+    bq_project_query(project_id,
+                     build_analyzed_probe_query(tbl.analyzed, probe = probe_client_count, os='Linux')) %>%
+    bq_table_download() %>%
+    as.data.table()
+}
+
+crash_client_count_plots <- list()
+
+for (probe in names(crashes_client_count)) {
+  df <- crashes_client_count[[probe]]
+  if (nrow(df) > 0) {
+    # print(probe)
+    crash_client_count_plots[[length(crash_client_count_plots) + 1]] <-
+      create.figure(
+        df,
+        title = probe,
+        yaxislab = 'Estimate',
+        width = W / 1.85,
+        height = H,
+        LA = 90
+      )
+  }
+}
+
+vw(list(config = list(
+  legend = list(
+    direction = 'horizontal',
+    orient = 'top',
+    title = NULL
+  )
+),
+vconcat = crash_client_count_plots) , TRUE)
+```
+
 
 
 ### Usage{.tabset}

--- a/analysis/dashboard.Rmd
+++ b/analysis/dashboard.Rmd
@@ -121,7 +121,7 @@ Hovering over each point reveals a pop-up displaying the build_id, branch, numbe
 
 Zoom: Use mouse-wheel, and double-click to reset.
 
-```{r eval=TRUE}
+```{r max_build, eval=TRUE}
 max_build_id <- bq_project_query(project_id, 
                                  glue("SELECT max(build_id) as max_build_id from {tbl.analyzed}")) %>%
   bq_table_download() %>% 
@@ -252,7 +252,7 @@ vw(list(
 
 #### 95th Percentile
 
-```{r eval=TRUE}
+```{r performance_95th, eval=TRUE}
 # query histogram datasets
 hists <- list()
 for (probe in names(probes.hist.perc.95)){

--- a/analysis/dashboard.Rmd
+++ b/analysis/dashboard.Rmd
@@ -152,7 +152,6 @@ performance_plots <- list()
 for (probe in names(hists)){
   df <- hists[[probe]]
   if (nrow(df) > 0) {
-    print(probe)
     performance_plots[[length(performance_plots) + 1]] <- create.figure(df, title=probe,
                     yaxislab='Estimate',width=W/1.85,height=H,
                     LA=90)
@@ -193,7 +192,7 @@ vw(list(
         ) ,TRUE)
 ```
 
-##### MAC
+##### Mac
 
 ```{r performance_osx, eval=TRUE}
 # query histogram datasets
@@ -284,10 +283,10 @@ vw(list(
 
 ### Stability{.tabset}
 
-#### Crash Rates: Per Hour
+#### Crash Rates: Per Hour{.tabset}
+##### OS: ALL
 
-
-```{r eval=TRUE}
+```{r crash_rates, eval=TRUE}
 # query analyzed per hour data
 crashes <- list()
 for (probe in names(probes.crashes)) {
@@ -327,10 +326,10 @@ vw(list(config = list(
 vconcat = crash_plots) , TRUE)
 ```
 
-#### Crash Rates: Unique Client Count
+#### Crash Rates: Unique Client Count{.tabset}
 
-
-```{r eval=TRUE}
+##### OS: ALL
+```{r crash_rates_nclients, eval=TRUE}
 # query analyzed per hour data
 crashes_client_count <- list()
 for (probe in names(probes.crashes)) {
@@ -371,13 +370,100 @@ vconcat = crash_client_count_plots) , TRUE)
 ```
 
 
-### Usage
-
-```{r eval=TRUE}
+### Usage{.tabset}
+#### OS: All
+```{r usage, eval=TRUE}
 usage <- list()
 for (probe in c(names(probes.scalar.sum), names(probes.scalar.max))){
   if (probe == 'GFX_OMTP_PAINT_WAIT_TIME_RATIO') next
   usage[[probe]] <- bq_project_query(project_id, build_analyzed_probe_query(tbl.analyzed, probe = probe)) %>%
+    bq_table_download() %>%
+    as.data.table()
+}
+
+usage_plots <- list()
+
+for (probe in names(usage)){
+  df <- usage[[probe]]
+  if (nrow(df) > 0) {
+    # print(probe)
+    usage_plots[[length(usage_plots) + 1]] <- create.figure(df, title=probe,
+                    yaxislab='Estimate',width=W/1.85,height=H,
+                    LA=90)
+  }
+}
+
+vw(list(
+    config = list( legend = list(direction='horizontal',orient='top',title=NULL)),
+    vconcat=usage_plots
+        ) ,TRUE)
+  
+```
+
+#### Windows
+```{r usage_windows, eval=TRUE}
+usage <- list()
+for (probe in c(names(probes.scalar.sum), names(probes.scalar.max))){
+  if (probe == 'GFX_OMTP_PAINT_WAIT_TIME_RATIO') next
+  usage[[probe]] <- bq_project_query(project_id, build_analyzed_probe_query(tbl.analyzed, probe = probe, os='Windows')) %>%
+    bq_table_download() %>%
+    as.data.table()
+}
+
+usage_plots <- list()
+
+for (probe in names(usage)){
+  df <- usage[[probe]]
+  if (nrow(df) > 0) {
+    # print(probe)
+    usage_plots[[length(usage_plots) + 1]] <- create.figure(df, title=probe,
+                    yaxislab='Estimate',width=W/1.85,height=H,
+                    LA=90)
+  }
+}
+
+vw(list(
+    config = list( legend = list(direction='horizontal',orient='top',title=NULL)),
+    vconcat=usage_plots
+        ) ,TRUE)
+  
+```
+
+#### Mac
+```{r usage_mac, eval=TRUE}
+usage <- list()
+for (probe in c(names(probes.scalar.sum), names(probes.scalar.max))){
+  if (probe == 'GFX_OMTP_PAINT_WAIT_TIME_RATIO') next
+  usage[[probe]] <- bq_project_query(project_id, build_analyzed_probe_query(tbl.analyzed, probe = probe, os='Mac')) %>%
+    bq_table_download() %>%
+    as.data.table()
+}
+
+usage_plots <- list()
+
+for (probe in names(usage)){
+  df <- usage[[probe]]
+  if (nrow(df) > 0) {
+    # print(probe)
+    usage_plots[[length(usage_plots) + 1]] <- create.figure(df, title=probe,
+                    yaxislab='Estimate',width=W/1.85,height=H,
+                    LA=90)
+  }
+}
+
+vw(list(
+    config = list( legend = list(direction='horizontal',orient='top',title=NULL)),
+    vconcat=usage_plots
+        ) ,TRUE)
+  
+```
+
+#### Linux
+```{r usage_linux, eval=TRUE}
+usage <- list()
+for (probe in c(names(probes.scalar.sum), names(probes.scalar.max))){
+  if (probe == 'GFX_OMTP_PAINT_WAIT_TIME_RATIO') next
+  usage[[probe]] <- bq_project_query(project_id, build_analyzed_probe_query(tbl.analyzed, probe = probe, os='Linux')) %>%
     bq_table_download() %>%
     as.data.table()
 }

--- a/analysis/dashboard.Rmd
+++ b/analysis/dashboard.Rmd
@@ -134,13 +134,43 @@ Information for builds up to `r as.Date(as.character(max_build_id), format = '%Y
 
 ### Performance{.tabset}
 
-#### Mean
+#### Mean{.tabset}
 
-```{r eval=TRUE}
+##### OS: All
+
+```{r performance, eval=TRUE}
 # query histogram datasets
 hists <- list()
 for (probe in c(names(probes.hist), 'GFX_OMTP_PAINT_WAIT_TIME_RATIO')){
   hists[[probe]] <- bq_project_query(project_id, build_analyzed_probe_query(tbl.analyzed, probe = probe)) %>%
+    bq_table_download() %>%
+    as.data.table()
+}
+
+performance_plots <- list()
+
+for (probe in names(hists)){
+  df <- hists[[probe]]
+  if (nrow(df) > 0) {
+    print(probe)
+    performance_plots[[length(performance_plots) + 1]] <- create.figure(df, title=probe,
+                    yaxislab='Estimate',width=W/1.85,height=H,
+                    LA=90)
+  }
+}
+
+vw(list(
+    config = list( legend = list(direction='horizontal',orient='top',title=NULL)),
+    vconcat=performance_plots
+        ) ,TRUE)
+```
+
+##### Windows
+```{r performance_windows, eval=TRUE}
+# query histogram datasets
+hists <- list()
+for (probe in c(names(probes.hist), 'GFX_OMTP_PAINT_WAIT_TIME_RATIO')){
+  hists[[probe]] <- bq_project_query(project_id, build_analyzed_probe_query(tbl.analyzed, probe = probe, os='Windows')) %>%
     bq_table_download() %>%
     as.data.table()
 }
@@ -163,7 +193,63 @@ vw(list(
         ) ,TRUE)
 ```
 
+##### MAC
 
+```{r performance_osx, eval=TRUE}
+# query histogram datasets
+hists <- list()
+for (probe in c(names(probes.hist), 'GFX_OMTP_PAINT_WAIT_TIME_RATIO')){
+  hists[[probe]] <- bq_project_query(project_id, build_analyzed_probe_query(tbl.analyzed, probe = probe, os='Mac')) %>%
+    bq_table_download() %>%
+    as.data.table()
+}
+
+performance_plots <- list()
+
+for (probe in names(hists)){
+  df <- hists[[probe]]
+  if (nrow(df) > 0) {
+    # print(probe)
+    performance_plots[[length(performance_plots) + 1]] <- create.figure(df, title=probe,
+                    yaxislab='Estimate',width=W/1.85,height=H,
+                    LA=90)
+  }
+}
+
+vw(list(
+    config = list( legend = list(direction='horizontal',orient='top',title=NULL)),
+    vconcat=performance_plots
+        ) ,TRUE)
+```
+
+##### Linux
+
+```{r performance_linux, eval=TRUE}
+# query histogram datasets
+hists <- list()
+for (probe in c(names(probes.hist), 'GFX_OMTP_PAINT_WAIT_TIME_RATIO')){
+  hists[[probe]] <- bq_project_query(project_id, build_analyzed_probe_query(tbl.analyzed, probe = probe, os='Linux')) %>%
+    bq_table_download() %>%
+    as.data.table()
+}
+
+performance_plots <- list()
+
+for (probe in names(hists)){
+  df <- hists[[probe]]
+  if (nrow(df) > 0) {
+    # print(probe)
+    performance_plots[[length(performance_plots) + 1]] <- create.figure(df, title=probe,
+                    yaxislab='Estimate',width=W/1.85,height=H,
+                    LA=90)
+  }
+}
+
+vw(list(
+    config = list( legend = list(direction='horizontal',orient='top',title=NULL)),
+    vconcat=performance_plots
+        ) ,TRUE)
+```
 
 #### 95th Percentile
 

--- a/analysis/process.R
+++ b/analysis/process.R
@@ -1,0 +1,82 @@
+process_histograms <- function(probe, os=NULL) {
+  hist.res <- tryCatch({
+    print(paste(probe, ': ', os, sep=''))
+    hist_query <-
+      build_hist_query(probes.hist[[probe]], slug, tbl.main, min_build_id, os=os)
+    hist <- bq_project_query(project_id, hist_query)
+    hist.df <- bq_table_download(hist) %>%
+      mutate(branch = case_when(
+        branch == 'fission-enabled' ~ 'enabled',
+        TRUE ~ 'disabled'
+      )) %>%
+      as.data.table()
+    
+    hist.summary <- summarize.hist(hist.df) %>%
+      mutate(probe = probe) %>%
+      rename(branch = what)
+    list(raw = hist.df, summary = hist.summary)
+  },
+  error = function(err) {
+    print(glue("ERROR processsing {probe}: {err}"))
+    return(c(raw = NULL, summary = NULL))
+  })
+  return(hist.res) 
+}
+
+process_histograms_95th <- function(probe, os=NULL) {
+  hist.res <- tryCatch({
+    print(probe)
+    hist_query <-
+      build_hist_query(probes.hist.perc.95[[probe]], slug, tbl.main, min_build_id, os=os)
+    hist <- bq_project_query(project_id, hist_query)
+    hist.df <- bq_table_download(hist) %>%
+      mutate(branch = case_when(
+        branch == 'fission-enabled' ~ 'enabled',
+        TRUE ~ 'disabled'
+      )) %>%
+      as.data.table()
+    
+    hist.summary.95th <- summarize.hist.perc(hist.df, 0.95) %>%
+      mutate(probe = probe) %>%
+      rename(branch = what)
+    list(raw = hist.df, summary = hist.summary.95th)
+  },
+  error = function(err) {
+    print(glue("ERROR processsing {probe}: {err}"))
+    return(c(raw = NULL, summary = NULL))
+  })
+  return(hist.res) 
+}
+
+process_scalar <- function(df, probe, perc.high, bs_replicates) {
+  scalar.res <- tryCatch({
+    df[get(probe) < quantile(get(probe), perc.high, na.rm = TRUE),
+              summarize.scalar(.SD[, list(id, branch, x =
+                                            get(probe))], "x", bs_replicates, stat = mean.narm),
+              by = build_id][, probe := probe][order(build_id, what),] %>%
+      rename(branch = what)
+  },
+  error = function(err) {
+    print(glue("ERROR processsing {probe}: {err}"))
+    return(NULL)
+  })
+  return(scalar.res)
+}
+
+process_crash <- function(probe, perc.high, bs_replicates, stat=mean.narm, name = probe) {
+  crashes.res <- tryCatch({
+    print(probe)
+    crashes.df[get(probe) < quantile(get(probe), perc.high, na.rm = TRUE),
+               summarize.scalar(.SD[, list(id, branch, x =
+                                             get(probe))], "x",
+                                bs_replicates, stat = stat),
+               by = build_id][, probe := probe][order(build_id, what), ] %>%
+      rename(branch = what) %>%
+      mutate(probe = name)
+  },
+  error = function(err) {
+    print(glue("ERROR processsing {probe}: {err}"))
+    return(NULL)
+  })
+  return(crashes.res)
+}

--- a/analysis/process.R
+++ b/analysis/process.R
@@ -63,10 +63,10 @@ process_scalar <- function(df, probe, perc.high, bs_replicates) {
   return(scalar.res)
 }
 
-process_crash <- function(probe, perc.high, bs_replicates, stat=mean.narm, name = probe) {
+process_crash <- function(df, probe, perc.high, bs_replicates, stat=mean.narm, name = probe) {
   crashes.res <- tryCatch({
     print(probe)
-    crashes.df[get(probe) < quantile(get(probe), perc.high, na.rm = TRUE),
+    df[get(probe) < quantile(get(probe), perc.high, na.rm = TRUE),
                summarize.scalar(.SD[, list(id, branch, x =
                                              get(probe))], "x",
                                 bs_replicates, stat = stat),

--- a/analysis/query.R
+++ b/analysis/query.R
@@ -240,7 +240,7 @@ build_delete_build_records_query <- function(tbl, min_build_id){
 build_analyzed_probe_query <- function(tbl, probe, os=NULL){
   additional_filters <- dplyr::case_when(
     !is.null(os) ~ paste("AND os = '", os,"'", sep='') ,
-    TRUE ~ "AND os = 'All'"
+    TRUE ~ "AND (os = 'All' OR os IS NULL)"
   )
   return(glue(analyzed_probe_query_base,
               tbl=tbl, additional_filters=additional_filters))


### PR DESCRIPTION
Adding segmentation of analysis and dashboard display by OS. Currently supports metrics:
* Performance: mean
* Stability
* Usage

95th percentile of Performance metrics isn't included. This could be added, if the computation time has been observed to reasonable, and the periodic job is stable. 

Regarding `analysis_etl.Rmd`, the update _adds_ additional analyses for segmentation by OS. An additional field has been added (`os`) to the export dataframe, and corresponding DB. `dashboard.Rmd` has additional tabs for each OS segment across the relevant metrics. 