### PR TITLE
Additional probe, limiting dashboarding

### DIFF
--- a/analysis/dashboard.Rmd
+++ b/analysis/dashboard.Rmd
@@ -125,6 +125,9 @@ max_build_id <- bq_project_query(project_id,
                                  glue("SELECT max(build_id) as max_build_id from {tbl.analyzed}")) %>%
   bq_table_download() %>% 
   pull(max_build_id)
+
+# remove FX_NUMBER_OF_UNIQUE_SITE_ORIGINS  from dashboard (but maintained in analysis)
+hist_probes <- names(probes.hist)[!sapply(names(probes.hist), startsWith, prefix = 'FX_NUMBER_OF_UNIQUE_SITE_ORIGINS')]
 ```
 
 Information for builds up to `r as.Date(as.character(max_build_id), format = '%Y%m%d')`.
@@ -140,7 +143,7 @@ Information for builds up to `r as.Date(as.character(max_build_id), format = '%Y
 ```{r performance, eval=TRUE}
 # query histogram datasets
 hists <- list()
-for (probe in c(names(probes.hist), 'GFX_OMTP_PAINT_WAIT_TIME_RATIO')){
+for (probe in c(hist_probes, 'GFX_OMTP_PAINT_WAIT_TIME_RATIO')){
   hists[[probe]] <- bq_project_query(project_id, build_analyzed_probe_query(tbl.analyzed, probe = probe)) %>%
     bq_table_download() %>%
     as.data.table()
@@ -167,7 +170,7 @@ vw(list(
 ```{r performance_windows, eval=TRUE}
 # query histogram datasets
 hists <- list()
-for (probe in c(names(probes.hist), 'GFX_OMTP_PAINT_WAIT_TIME_RATIO')){
+for (probe in c(hist_probes, 'GFX_OMTP_PAINT_WAIT_TIME_RATIO')){
   hists[[probe]] <- bq_project_query(project_id, build_analyzed_probe_query(tbl.analyzed, probe = probe, os='Windows')) %>%
     bq_table_download() %>%
     as.data.table()
@@ -195,7 +198,7 @@ vw(list(
 ```{r performance_osx, eval=TRUE}
 # query histogram datasets
 hists <- list()
-for (probe in c(names(probes.hist), 'GFX_OMTP_PAINT_WAIT_TIME_RATIO')){
+for (probe in c(hist_probes, 'GFX_OMTP_PAINT_WAIT_TIME_RATIO')){
   hists[[probe]] <- bq_project_query(project_id, build_analyzed_probe_query(tbl.analyzed, probe = probe, os='Mac')) %>%
     bq_table_download() %>%
     as.data.table()
@@ -223,7 +226,7 @@ vw(list(
 ```{r performance_linux, eval=TRUE}
 # query histogram datasets
 hists <- list()
-for (probe in c(names(probes.hist), 'GFX_OMTP_PAINT_WAIT_TIME_RATIO')){
+for (probe in c(hist_probes, 'GFX_OMTP_PAINT_WAIT_TIME_RATIO')){
   hists[[probe]] <- bq_project_query(project_id, build_analyzed_probe_query(tbl.analyzed, probe = probe, os='Linux')) %>%
     bq_table_download() %>%
     as.data.table()

--- a/analysis/params.R
+++ b/analysis/params.R
@@ -6,6 +6,8 @@ exp_min_build_id <- 20201012
 #### Analysis-specific ####
 # Breakdown by how probes are analyzed # 
 probes.hist <- list(
+  'CONTENT_PROCESS_COUNT' = 'payload.histograms.content_process_count',
+  # 'CONTENT_PROCESS_MAX' =  'payload.histograms.content_process_max',
   "CHECKERBOARDING_SEVERITY" = 'payload.processes.gpu.histograms.checkerboard_severity',
   "CHILD_PROCESS_LAUNCH_MS" = 'payload.histograms.child_process_launch_ms',
   "CONTENT_FRAME_TIME_VSYNC" = 'payload.histograms.content_frame_time_vsync',


### PR DESCRIPTION
Added new probe to `params.R`. Updated dashboarding to exclude a suite of probe from display - though maintaining its analysis and export to derived tables. 